### PR TITLE
feat: stream and sequence behind an interface, allows future extensions

### DIFF
--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -1,0 +1,11 @@
+package api
+
+import "time"
+
+type SequenceGenerator interface {
+	Next() float64
+	NextFor(interval time.Duration) (bool, *float64, int64)
+	Size() int64
+	GetStartTimestamp(interval time.Duration) int64
+	AdjustTime(timestamp int64)
+}

--- a/api/sequence.go
+++ b/api/sequence.go
@@ -34,14 +34,19 @@ func (s *Sequence) Size() int64 {
 	return s.Times
 }
 
-func (s *SequenceList) Next(interval time.Duration) (bool, *float64, int64) {
+// Next not implemented for this type
+func (s *SequenceList) Next() float64 {
+	panic("Next not implemented for this type")
+}
+
+func (s *SequenceList) NextFor(interval time.Duration) (bool, *float64, int64) {
 	if s.index >= len(s.sequences) {
 		return false, nil, 0
 	}
 	valid, next := s.sequences[s.index].Next()
 	if !valid {
 		s.index += 1
-		return s.Next(interval)
+		return s.NextFor(interval)
 	}
 
 	ts := s.startTimestamp + (s.timesAlready * interval.Milliseconds())
@@ -53,7 +58,7 @@ func (s *SequenceList) AsIntArray(interval time.Duration) []int {
 	var result []int
 
 	for true {
-		valid, next, _ := s.Next(interval)
+		valid, next, _ := s.NextFor(interval)
 		if !valid {
 			break
 		}

--- a/api/stream.go
+++ b/api/stream.go
@@ -1,10 +1,32 @@
 package api
 
+import "time"
+
 type Stream struct {
 	timesAlready int64
 
 	Initial   float64
 	Increment float64
+}
+
+// NextFor not implemented for this type
+func (s *Stream) NextFor(interval time.Duration) (bool, *float64, int64) {
+	panic("NextFor not implemented for this type")
+}
+
+// Size not implemented for this type
+func (s *Stream) Size() int64 {
+	panic("Size not implemented for this type")
+}
+
+// GetStartTimestamp not implemented for this type
+func (s *Stream) GetStartTimestamp(interval time.Duration) int64 {
+	panic("GetStartTimestamp not implemented for this type")
+}
+
+// AdjustTime not implemented for this type
+func (s *Stream) AdjustTime(timestamp int64) {
+	panic("AdjustTime not implemented for this type")
 }
 
 func (s *Stream) Next() float64 {

--- a/pkg/precalculated/scheduler.go
+++ b/pkg/precalculated/scheduler.go
@@ -14,7 +14,7 @@ import (
 func SchedulePrecalculatedRemoteWriteRequests(config *api.Config, batchSize int) ([]*prometheus.WriteRequest, int64, error) {
 	type generator struct {
 		ts  *prometheus.TimeSeries
-		seq *api.SequenceList
+		seq api.SequenceGenerator
 	}
 	var totalSamples int64
 	var generators []generator
@@ -84,7 +84,7 @@ func SchedulePrecalculatedRemoteWriteRequests(config *api.Config, batchSize int)
 		g := generators[iterations%len(generators)]
 		iterations += 1
 
-		valid, value, timestamp := g.seq.Next(interval)
+		valid, value, timestamp := g.seq.NextFor(interval)
 		if !valid {
 			continue
 		}

--- a/pkg/sequence/parser.go
+++ b/pkg/sequence/parser.go
@@ -110,7 +110,7 @@ func (p *Parser) parseValueSequence() (*api.Sequence, error) {
 	return sequence, nil
 }
 
-func (p *Parser) ParseStream() (*api.Stream, error) {
+func (p *Parser) ParseStream() (api.SequenceGenerator, error) {
 	stream := &api.Stream{}
 	initial, err := p.Expect(TokenTypeNumber)
 	if err != nil {

--- a/pkg/sequence/sequence.go
+++ b/pkg/sequence/sequence.go
@@ -4,7 +4,7 @@ import (
 	"github.com/pb82/prometheus-toolbox/api"
 )
 
-func ScanAndParseSequence(source string) (*api.SequenceList, error) {
+func ScanAndParseSequence(source string) (api.SequenceGenerator, error) {
 	scanner := NewScanner(source)
 	scanner.Scan()
 

--- a/pkg/sequence/stream.go
+++ b/pkg/sequence/stream.go
@@ -2,7 +2,7 @@ package sequence
 
 import "github.com/pb82/prometheus-toolbox/api"
 
-func ScanAndParseStream(source string) (*api.Stream, error) {
+func ScanAndParseStream(source string) (api.SequenceGenerator, error) {
 	scanner := NewScanner(source)
 	scanner.Scan()
 


### PR DESCRIPTION
Adds a common interface for sequences (precalculated samples) and streams (continuous samples). The idea is to add additional value providers like a scripted sequence, etc.